### PR TITLE
Jin/41/path for workflow trigger include iac

### DIFF
--- a/.github/workflows/LOB-ILB-ASEv3-Bicep.yml
+++ b/.github/workflows/LOB-ILB-ASEv3-Bicep.yml
@@ -7,13 +7,18 @@ on:
     branches:
     - main
     paths:
-      - 'reference-implementations/LOB-ILB-ASEv3/bicep/**'
+      - 'reference-implementations/LOB-ILB-ASEv3/**'
+      - '!reference-implementations/LOB-ILB-ASEv3/terraform/**'
 
   pull_request:
     branches:
     - main
     paths:
-      - 'reference-implementations/LOB-ILB-ASEv3/bicep/**'
+      - 'reference-implementations/LOB-ILB-ASEv3/**'
+      - '!reference-implementations/LOB-ILB-ASEv3/terraform/**'
+
+env:
+  modulePath: 'reference-implementations/LOB-ILB-ASEv3/terraform'
 
 jobs:
   validate_bicep:
@@ -25,7 +30,7 @@ jobs:
 
       - name: Validate that bicep builds
         run: az bicep build -f main.bicep
-        working-directory: ./reference-implementations/LOB-ILB-ASEv3/bicep
+        working-directory: ${{ env.modulePath }}
 
   build-and-deploy:
     name: "Deploy Bicep templates"
@@ -40,7 +45,7 @@ jobs:
       - name: Variable substitution
         uses: microsoft/variable-substitution@v1
         with:
-          files:  ./reference-implementations/LOB-ILB-ASEv3/bicep/config.yml
+          files:  ${{ env.modulePath }}/config.yml
         env:
           ACCOUNT_NAME: ${{ secrets.AZURE_SUBSCRIPTION }}
 
@@ -51,7 +56,7 @@ jobs:
 
       - name: Parse config.yaml as output to GitHub Actions matrix
         run: |
-          echo "config=$(yq e ./reference-implementations/LOB-ILB-ASEv3/bicep/config.yml -j -I=0)" >> $GITHUB_ENV
+          echo "config=$(yq e ${{ env.modulePath }}/config.yml -j -I=0)" >> $GITHUB_ENV
 
       - name: Write deployment information to log
         run: |
@@ -62,7 +67,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Run Preflight Validation
-        working-directory: ./reference-implementations/LOB-ILB-ASEv3/bicep
+        working-directory: ${{ env.modulePath }}
         run: |
             az deployment sub validate \
               --location ${{ fromJson(env.config).AZURE_LOCATION }} \
@@ -79,7 +84,7 @@ jobs:
           scope: subscription
           region: ${{ fromJson(env.config).AZURE_LOCATION }}
           deploymentName:  ${{ fromJson(env.config).DEPLOYMENT_NAME }}
-          template: ./reference-implementations/LOB-ILB-ASEv3/bicep/main.bicep
+          template: ${{ env.modulePath }}/main.bicep
           parameters: >
             workloadName=${{ fromJson(env.config).RESOURCE_NAME_PREFIX }} environment=${{ fromJson(env.config).ENVIRONMENT_TAG }}
             vmUsername=${{ fromJson(env.config).VM_USERNAME }} vmPassword=${{ secrets.VM_PW }} location=${{ fromJson(env.config).AZURE_LOCATION }} 

--- a/.github/workflows/LOB-ILB-ASEv3-Terraform.yml
+++ b/.github/workflows/LOB-ILB-ASEv3-Terraform.yml
@@ -1,0 +1,67 @@
+name: 'ASEv3 Terraform'
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+    - main
+    paths:
+      - 'reference-implementations/LOB-ILB-ASEv3/**'
+      - '!reference-implementations/LOB-ILB-ASEv3/bicep/**'
+
+  pull_request:
+    branches:
+    - main
+    paths:
+      - 'reference-implementations/LOB-ILB-ASEv3/**'
+      - '!reference-implementations/LOB-ILB-ASEv3/bicep/**'
+
+env:
+  modulePath: 'reference-implementations/LOB-ILB-ASEv3/terraform'
+
+jobs:
+  validate_bicep:
+    name: "Validate Terraform files"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
+      - name: Validate that bicep builds
+        run: az bicep build -f main.bicep
+        working-directory: ${{ env.modulePath }}
+
+  build-and-deploy:
+    name: "Deploy Bicep templates"
+    needs: validate_bicep
+    runs-on: ubuntu-latest
+    steps:
+
+        # Checkout code
+      - name: Checkout the code
+        uses: actions/checkout@main
+
+      - name: Setup Terraform on agent
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.1.8
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Terraform Validate
+        working-directory: ${{ env.modulePath }}
+        run: |
+          terraform init
+          terraform validate
+
+      - name: Write deployment information to log
+        working-directory: ${{ env.modulePath }}
+        run: terraform plan
+
+        # Deploy Bicep file, need to point parameters to the main.parameters.json location
+      - name: deploy
+        working-directory: ${{ env.modulePath }}
+        run: terraform apply -auto-approve -input=false


### PR DESCRIPTION
Changes:
- Created a separate workflow file for Terraform - as the current workflow does not accommodate for it
- Workflow trigger conditions for push and PR currently include all under the `LOB-ILB-ASEv3` directory excluding either the bicep or terraform directory depending on workflow, to allow them to be handled independently.

Note:
- I have not been able to test this yet