### PR TITLE
Including the location as part of the deployment name

### DIFF
--- a/.github/workflows/LOB-ILB-ASEv3-Bicep.yml
+++ b/.github/workflows/LOB-ILB-ASEv3-Bicep.yml
@@ -1,19 +1,19 @@
-name: 'AzureBicepDeploy'
+name: "AzureBicepDeploy"
 
 on:
   workflow_dispatch:
 
   push:
     branches:
-    - main
+      - main
     paths:
-      - 'reference-implementations/LOB-ILB-ASEv3/bicep/**'
+      - "reference-implementations/LOB-ILB-ASEv3/bicep/**"
 
   pull_request:
     branches:
-    - main
+      - main
     paths:
-      - 'reference-implementations/LOB-ILB-ASEv3/bicep/**'
+      - "reference-implementations/LOB-ILB-ASEv3/bicep/**"
 
 jobs:
   validate_bicep:
@@ -32,15 +32,14 @@ jobs:
     needs: validate_bicep
     runs-on: ubuntu-latest
     steps:
-
-        # Checkout code
+      # Checkout code
       - name: Checkout the code
         uses: actions/checkout@main
 
       - name: Variable substitution
         uses: microsoft/variable-substitution@v1
         with:
-          files:  ./reference-implementations/LOB-ILB-ASEv3/bicep/config.yml
+          files: ./reference-implementations/LOB-ILB-ASEv3/bicep/config.yml
         env:
           ACCOUNT_NAME: ${{ secrets.AZURE_SUBSCRIPTION }}
 
@@ -64,12 +63,12 @@ jobs:
       - name: Run Preflight Validation
         working-directory: ./reference-implementations/LOB-ILB-ASEv3/bicep
         run: |
-            az deployment sub validate \
-              --location ${{ fromJson(env.config).AZURE_LOCATION }} \
-              --parameters workloadName=${{ fromJson(env.config).RESOURCE_NAME_PREFIX }} environment=${{ fromJson(env.config).ENVIRONMENT_TAG }} \
-              vmUsername=${{ fromJson(env.config).VM_USERNAME }} vmPassword=${{ secrets.VM_PW }}  location=${{ fromJson(env.config).AZURE_LOCATION }}\
-              accountName=${{ secrets.ACCOUNT_NAME }} personalAccessToken=${{ secrets.PAT }} CICDAgentType=${{ fromJson(env.config).CICD_AGENT_TYPE}} \
-              --template-file main.bicep
+          az deployment sub validate \
+            --location ${{ fromJson(env.config).AZURE_LOCATION }} \
+            --parameters workloadName=${{ fromJson(env.config).RESOURCE_NAME_PREFIX }} environment=${{ fromJson(env.config).ENVIRONMENT_TAG }} \
+            vmUsername=${{ fromJson(env.config).VM_USERNAME }} vmPassword=${{ secrets.VM_PW }}  location=${{ fromJson(env.config).AZURE_LOCATION }}\
+            accountName=${{ secrets.ACCOUNT_NAME }} personalAccessToken=${{ secrets.PAT }} CICDAgentType=${{ fromJson(env.config).CICD_AGENT_TYPE}} \
+            --template-file main.bicep
 
         # Deploy Bicep file, need to point parameters to the main.parameters.json location
       - name: deploy
@@ -78,7 +77,7 @@ jobs:
           subscriptionId: ${{ secrets.AZURE_SUBSCRIPTION }}
           scope: subscription
           region: ${{ fromJson(env.config).AZURE_LOCATION }}
-          deploymentName:  ${{ fromJson(env.config).DEPLOYMENT_NAME }}
+          deploymentName: "${{ fromJson(env.config).DEPLOYMENT_NAME }}-${{ fromJson(env.config).AZURE_LOCATION }}"
           template: ./reference-implementations/LOB-ILB-ASEv3/bicep/main.bicep
           parameters: >
             workloadName=${{ fromJson(env.config).RESOURCE_NAME_PREFIX }} environment=${{ fromJson(env.config).ENVIRONMENT_TAG }}


### PR DESCRIPTION
Previously the deployment would fail if the targeted location changed, as the deployment's name targeting subscription must be unique per location. 

The location is now included as part of used deployment name.

