### PR TITLE
fix: WAF on AFD should always be ON by default

### DIFF
--- a/scenarios/secure-baseline-multitenant/azure-resource-manager/main.parameters.jsonc
+++ b/scenarios/secure-baseline-multitenant/azure-resource-manager/main.parameters.jsonc
@@ -20,9 +20,6 @@
         "enableEgressLockdown" : {
             "value": "true"
         },
-        "enableWaf": {
-            "value": "true"
-        },
         "deployRedis": {
             "value": "false"
         },

--- a/scenarios/secure-baseline-multitenant/bicep/README.md
+++ b/scenarios/secure-baseline-multitenant/bicep/README.md
@@ -79,9 +79,9 @@ az deployment sub create `
 The approval of the App Service private endpoint connection from Azure Front Door can be automated with the deployment, if you set the param `autoApproveAfdPrivateEndpoint` to `true`. If you do so then you need to know:
 - The automatic deployment uses the [deploymentScripts Resource](https://learn.microsoft.com/en-us/azure/templates/microsoft.resources/deploymentscripts?pivots=deployment-language-bicep). The deployment script service requires two supporting resources for script execution and troubleshooting: a storage account and a container instance. The two automatically-created supporting resources are usually deleted by the script service when the deployment script execution gets in a terminal state. You are billed for the supporting resources until they are deleted.
 - The deployment script resource is only available in the regions where Azure Container Instance is available, see [Azure Container Instances Availabiility by Region](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/?products=container-instances&regions=asia-pacific-east,asia-pacific-southeast,australia-central,australia-central-2,australia-east,australia-southeast,brazil-south,brazil-southeast,canada-central,canada-east,central-india,china-east,china-east-2,china-east-3,china-non-regional,china-north,china-north-2,china-north-3,europe-north,europe-west,france-central,france-south,germany-north,germany-west-central,japan-east,japan-west,korea-central,korea-south,norway-east,norway-west,qatar-central,south-africa-north,south-africa-west,south-india,sweden-central,sweden-south,switzerland-north,switzerland-west,uae-north,uae-central,united-kingdom-south,united-kingdom-west,us-central,us-dod-central,us-dod-east,us-east,us-east-2,us-north-central,us-south-central,us-west,us-west-2,us-west-3,us-west-central,usgov-arizona,usgov-non-regional,usgov-texas,usgov-virginia,west-india,poland-central)
-- A User Assigned Managed Identity will be created (with name *id-WORKLOADNAME-ENVIRONMENT-REGION-AfdApprovePe*) that it will be given Contributor role on the spoke resource group. This idenity will be used to approve the Private Endpoint connection
+- A User Assigned Managed Identity will be created (with name *id-WORKLOADNAME-ENVIRONMENT-REGION-AfdApprovePe*) that it will be given Contributor role on the spoke resource group. This identity will be used to approve the Private Endpoint connection
 
-If before deployment you set the param `autoApproveAfdPrivateEndpoint` to `false` (because you want to manually approve the PRivate Endpoint) then you need to complete this manual step to approve the private endpoint connection.
+If before deployment you set the param `autoApproveAfdPrivateEndpoint` to `false` (because you want to manually approve the Private Endpoint) then you need to complete the next manual step to approve the private endpoint connection.
 
 ```bash
 # Update the resource group name to match the one used in the deployment of the webapp
@@ -90,6 +90,9 @@ webapp_id=$(az webapp list -g $rg_name --query "[].id" -o tsv)
 fd_conn_id=$(az network private-endpoint-connection list --id $webapp_id --query "[?properties.provisioningState == 'Pending'].{id:id}" -o tsv)
 az network private-endpoint-connection approve --id $fd_conn_id --description "Approved"
 ```
+
+### Verify Deployment and Approval of Azure Front Door Private Endpoint Connection approval
+Go to the portal, find the spoke resource group you have just deployed, and identify the Azure Front Door resource (names starts with *afd-*). In the Overview page, find the URL named *Endpoint hostname*, copy it, and try it on a browser. If everything is successful then you should see a sample web app page with title *"Your web app is running and waiting for your content"*. If you get any errors verify that you have approved the private endpoint connection between Azure Front Door and the Web App. 
 
 ### Connect to the Jumpbox VM (deployed in the spoke resource group)
 

--- a/scenarios/secure-baseline-multitenant/bicep/README.md
+++ b/scenarios/secure-baseline-multitenant/bicep/README.md
@@ -38,7 +38,8 @@ The table below summurizes the avaialble parameters and the possible values that
 |deployAzureSql|Feature Flag: Deploy (or not) an Azure SQL with default database|
 |deployAppConfig|Feature Flag: Deploy (or not) an Azure app configuration|
 |deployJumpHost|Feature Flag: Deploy (or not) an Azure virtual machine (to be used as jumphost)|
-|sqlServerAdministrators|The Azure Active Directory (AAD) administrator group used for SQL Server authentication.  The Azure AD group  must be created before running deployment. This has three values that need to be filled, as shown below <br> **login**: the name of the AAD Group <br> **sid**: the object id  of the AAD Group <br> **tenantId**: The tenantId of the AAD ||
+|autoApproveAfdPrivateEndpoint|Default value: true. Set to true if you want to auto approve the Private Endpoint of the AFD Premium. See details [regarding approving the App Service private endpoint connection from Front Door](#approve-the-app-service-private-endpoint-connection-from-front-door-in-the-azure-portal) | false
+|sqlServerAdministrators|The Azure Active Directory (AAD) administrator group used for SQL Server authentication.  The Azure AD group must be created before running deployment. This has three values that need to be filled, as shown below <br> **login**: the name of the AAD Group <br> **sid**: the object id  of the AAD Group <br> **tenantId**: The tenantId of the AAD ||
 
 After the parameters have been initialized, you can deploy the Landing Zone Accelerator resources with the following `az cli` command:
 
@@ -75,7 +76,12 @@ az deployment sub create `
    
 ### Approve the App Service private endpoint connection from Front Door in the Azure Portal
 
-This is a manual step that is required to complete the private endpoint connection.
+The approval of the App Service private endpoint connection from Azure Front Door can be automated with the deployment, if you set the param `autoApproveAfdPrivateEndpoint` to `true`. If you do so then you need to know:
+- The automatic deployment uses the [deploymentScripts Resource](https://learn.microsoft.com/en-us/azure/templates/microsoft.resources/deploymentscripts?pivots=deployment-language-bicep). The deployment script service requires two supporting resources for script execution and troubleshooting: a storage account and a container instance. The two automatically-created supporting resources are usually deleted by the script service when the deployment script execution gets in a terminal state. You are billed for the supporting resources until they are deleted.
+- The deployment script resource is only available in the regions where Azure Container Instance is available, see [Azure Container Instances Availabiility by Region](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/?products=container-instances&regions=asia-pacific-east,asia-pacific-southeast,australia-central,australia-central-2,australia-east,australia-southeast,brazil-south,brazil-southeast,canada-central,canada-east,central-india,china-east,china-east-2,china-east-3,china-non-regional,china-north,china-north-2,china-north-3,europe-north,europe-west,france-central,france-south,germany-north,germany-west-central,japan-east,japan-west,korea-central,korea-south,norway-east,norway-west,qatar-central,south-africa-north,south-africa-west,south-india,sweden-central,sweden-south,switzerland-north,switzerland-west,uae-north,uae-central,united-kingdom-south,united-kingdom-west,us-central,us-dod-central,us-dod-east,us-east,us-east-2,us-north-central,us-south-central,us-west,us-west-2,us-west-3,us-west-central,usgov-arizona,usgov-non-regional,usgov-texas,usgov-virginia,west-india,poland-central)
+- A User Assigned Managed Identity will be created (with name *id-WORKLOADNAME-ENVIRONMENT-REGION-AfdApprovePe*) that it will be given Contributor role on the spoke resource group. This idenity will be used to approve the Private Endpoint connection
+
+If before deployment you set the param `autoApproveAfdPrivateEndpoint` to `false` (because you want to manually approve the PRivate Endpoint) then you need to complete this manual step to approve the private endpoint connection.
 
 ```bash
 # Update the resource group name to match the one used in the deployment of the webapp

--- a/scenarios/secure-baseline-multitenant/bicep/deploy.spoke.bicep
+++ b/scenarios/secure-baseline-multitenant/bicep/deploy.spoke.bicep
@@ -30,9 +30,6 @@ param tags object
 @description('Create (or not) a UDR for the App Service Subnet, to route all egress traffic through Hub Azure Firewall')
 param enableEgressLockdown bool
 
-@description('Enable or disable WAF policies for the deployed Azure Front Door')
-param enableWaf bool = true
-
 @description('Deploy (or not) a redis cache')
 param deployRedis bool
 
@@ -266,7 +263,7 @@ module afd '../../shared/bicep/network/front-door.bicep' = {
       }
     ]
     skuName:'Premium_AzureFrontDoor'
-    wafPolicyName: (enableWaf) ?  resourceNames.frontDoorWaf : ''
+    wafPolicyName: resourceNames.frontDoorWaf 
   }
 }
 

--- a/scenarios/secure-baseline-multitenant/bicep/deploy.spoke.bicep
+++ b/scenarios/secure-baseline-multitenant/bicep/deploy.spoke.bicep
@@ -67,6 +67,9 @@ param sqlAdminLogin string = ''
 @secure()
 param sqlAdminPassword string = ''
 
+@description('set to true if you want to auto approve the Private Endpoint of the AFD')
+param autoApproveAfdPrivateEndpoint bool = true
+
 var resourceNames = {
   storageAccount: naming.storageAccount.nameUnique
   vnetSpoke: take('${naming.virtualNetwork.name}-spoke', 80)
@@ -90,6 +93,7 @@ var resourceNames = {
   frontDoorWaf: naming.frontDoorFirewallPolicy.name
   routeTable: naming.routeTable.name
   routeEgressLockdown: '${naming.route.name}-egress-lockdown'
+  idAfdApprovePeAutoApprover: take('${naming.userAssignedManagedIdentity.name}-AfdApprovePe', 128)
 }
 
 var udrRoutes = [
@@ -265,6 +269,17 @@ module afd '../../shared/bicep/network/front-door.bicep' = {
     skuName:'Premium_AzureFrontDoor'
     wafPolicyName: resourceNames.frontDoorWaf 
   }
+}
+
+module autoApproveAfdPe 'modules/approve-afd-pe.module.bicep' = if (autoApproveAfdPrivateEndpoint) {
+  name: take ('autoApproveAfdPe-${resourceNames.frontDoor}-deployment', 64)
+  params: { 
+    location: location
+    idAfdPeAutoApproverName: resourceNames.idAfdApprovePeAutoApprover
+  }
+  dependsOn: [
+    afd
+  ]
 }
 
 

--- a/scenarios/secure-baseline-multitenant/bicep/main.bicep
+++ b/scenarios/secure-baseline-multitenant/bicep/main.bicep
@@ -76,9 +76,6 @@ param sqlAdminPassword string = newGuid()
 @description('set to true if you want to intercept all outbound traffic with azure firewall')
 param enableEgressLockdown bool = false
 
-@description('set to true if you want to deploy a WAF in front of the app service')
-param enableWaf bool = true
-
 @description('set to true if you want to a redis cache')
 param deployRedis bool = false
 
@@ -187,7 +184,6 @@ module spoke 'deploy.spoke.bicep' = {
     sqlAdminPassword: sqlAdminPassword  
     webAppPlanSku: webAppPlanSku 
     enableEgressLockdown: enableEgressLockdown
-    enableWaf: enableWaf
     deployJumpHost: deployJumpHost
     deployRedis: deployRedis
     deployAzureSql: deployAzureSql

--- a/scenarios/secure-baseline-multitenant/bicep/main.bicep
+++ b/scenarios/secure-baseline-multitenant/bicep/main.bicep
@@ -88,6 +88,9 @@ param deployAppConfig bool = false
 @description('set to true if you want to deploy a jumpbox/devops VM')
 param deployJumpHost bool = true
 
+@description('set to true if you want to auto approve the Private Endpoint of the AFD')
+param autoApproveAfdPrivateEndpoint bool = true
+
 
 
 // ================ //
@@ -188,6 +191,7 @@ module spoke 'deploy.spoke.bicep' = {
     deployRedis: deployRedis
     deployAzureSql: deployAzureSql
     deployAppConfig: deployAppConfig
+    autoApproveAfdPrivateEndpoint: autoApproveAfdPrivateEndpoint
   }
 }
 

--- a/scenarios/secure-baseline-multitenant/bicep/main.parameters.json
+++ b/scenarios/secure-baseline-multitenant/bicep/main.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "workloadName" : {
-           "value": "appsvclza2"         
+           "value": "appsvclza3"         
         },
         "environmentName": {
             "value": "${AZURE_ENV_NAME}"
@@ -19,9 +19,6 @@
         },
         "enableEgressLockdown" : {
             "value": "false"
-        },
-        "enableWaf": {
-            "value": "true"
         },
         "deployRedis": {
             "value": "false"

--- a/scenarios/secure-baseline-multitenant/bicep/main.parameters.json
+++ b/scenarios/secure-baseline-multitenant/bicep/main.parameters.json
@@ -32,6 +32,9 @@
         "deployJumpHost": {
             "value": "true"
         },
+        "autoApproveAfdPrivateEndpoint": {
+            "value": "true"
+        },
         "subnetHubFirewallAddressSpace": {
             "value": "10.242.0.0/26"
         },

--- a/scenarios/secure-baseline-multitenant/bicep/main.parameters.jsonc
+++ b/scenarios/secure-baseline-multitenant/bicep/main.parameters.jsonc
@@ -26,10 +26,6 @@
         "enableEgressLockdown" : {
             "value": "true"
         },
-        // set to true if you want to deploy a WAF in front of the app service
-        "enableWaf": {
-            "value": "true"
-        },
         // set to true if you want to a redis cache
         "deployRedis": {
             "value": "true"

--- a/scenarios/secure-baseline-multitenant/bicep/main.parameters.jsonc
+++ b/scenarios/secure-baseline-multitenant/bicep/main.parameters.jsonc
@@ -42,6 +42,10 @@
         "deployJumpHost": {
             "value": "true"
         },
+        // set to true if you want to auto approve the Private Endpoint of the AFD Premium
+        "autoApproveAfdPrivateEndpoint": {
+            "value": "true"
+        },
         // CIDR of the subnet that will host the azure Firewall
         "subnetHubFirewallAddressSpace": {
             "value": "10.242.0.0/26"

--- a/scenarios/secure-baseline-multitenant/bicep/modules/approve-afd-pe.module.bicep
+++ b/scenarios/secure-baseline-multitenant/bicep/modules/approve-afd-pe.module.bicep
@@ -1,0 +1,71 @@
+
+@description('Optional. The location to deploy the Redis cache service.')
+param location string 
+
+@description('Default value is OK. Sets how the deployment script should be forced to execute even if the script resource has not changed. Can be current time stamp')
+param utcValue string = utcNow()
+
+@description('Optional. The name of the user-assigned identity to be used to auto-approve the private endpoint connection of the AFD. Changing this forces a new resource to be created.')
+param idAfdPeAutoApproverName string = guid(resourceGroup().id, 'userAssignedIdentity')
+
+
+var roleAssignmentName = guid(resourceGroup().id, 'contributor')
+var contributorRoleDefinitionId = resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+var deploymentScriptName = 'runAfdApproval'
+
+
+@description('The User Assigned MAnaged Identity that will be given Contributor role on the Resource Group in order to auto-approve the Private Endpoint Connection of the AFD.')
+resource userAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: idAfdPeAutoApproverName
+  location: location
+}
+
+@description('The role assignment that will be created to give the User Assigned Managed Identity Contributor role on the Resource Group in order to auto-approve the Private Endpoint Connection of the AFD.')
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: roleAssignmentName
+  scope: resourceGroup()
+  properties: {
+    roleDefinitionId: contributorRoleDefinitionId
+    principalId: userAssignedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+@description('The deployment script that will be used to auto-approve the Private Endpoint Connection of the AFD.')
+resource runAfdApproval 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: deploymentScriptName
+  location: location
+  kind: 'AzureCLI'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${userAssignedIdentity.id}': {}
+    }
+  }
+  properties: {
+    forceUpdateTag: utcValue
+    azCliVersion: '2.47.0'
+    timeout: 'PT30M'
+    environmentVariables: [
+      {
+        name: 'ResourceGroupName'
+        value: resourceGroup().name
+      }
+    ]
+    scriptContent: 'rg_name="$ResourceGroupName"; webapp_id=$(az webapp list -g $rg_name --query "[].id" -o tsv); fd_conn_id=$(az network private-endpoint-connection list --id $webapp_id --query "[?properties.provisioningState == \'Pending\'].{id:id}" -o tsv);az network private-endpoint-connection approve --id $fd_conn_id --description "ApprovedByCli"'
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+  }
+  dependsOn: [
+    roleAssignment
+  ]
+}
+
+@description('The logs of the deployment script that will be used to auto-approve the Private Endpoint Connection of the AFD.')
+resource log 'Microsoft.Resources/deploymentScripts/logs@2020-10-01' existing = {
+  parent: runAfdApproval
+  name: 'default'
+}
+
+@description('The output of the deployment script that will be used to auto-approve the Private Endpoint Connection of the AFD.')
+output logs string = log.properties.log

--- a/scenarios/shared/bicep/network/front-door.bicep
+++ b/scenarios/shared/bicep/network/front-door.bicep
@@ -33,7 +33,7 @@ param origins array
 @description('Optional, default value false. Set true if you need to cache content at the AFD level')
 param enableCaching bool = false
 
-@description('Name of the WAF policy to create. Set empty string if not WAF policy is required. Alphanumerics only!')
+@description('Name of the WAF policy to create.')
 @maxLength(128)
 param wafPolicyName string
 
@@ -295,14 +295,14 @@ resource originRoute 'Microsoft.Cdn/profiles/afdendpoints/routes@2021-06-01' =  
   ]
 }
 
-resource afdWafSecurityPolicy 'Microsoft.Cdn/profiles/securitypolicies@2022-11-01-preview' =  if ( !empty(wafPolicyName) ) {
+resource afdWafSecurityPolicy 'Microsoft.Cdn/profiles/securitypolicies@2022-11-01-preview' =  {
   parent: profile
   name: 'afdWafSecurityPolicy'
-  properties: !empty(wafPolicyName) ? {
+  properties: {
     parameters: {
-      wafPolicy: !empty(wafPolicyName) ? {
+      wafPolicy: {
         id:  waf.id
-      } : {}
+      }
       associations: [
         {
           domains: endPointIdsForWaf
@@ -313,7 +313,7 @@ resource afdWafSecurityPolicy 'Microsoft.Cdn/profiles/securitypolicies@2022-11-0
       ]
       type: 'WebApplicationFirewall'
     }
-  } : {}
+  }
 }
 
 resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if ( !empty(diagnosticWorkspaceId)) {
@@ -326,7 +326,7 @@ resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-pr
   scope: profile
 }
 
-resource waf 'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@2022-05-01' =  if ( !empty(wafPolicyName) ){
+resource waf 'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@2022-05-01' =  {
   name: wafPolicyName
   location: 'Global'
   sku: {


### PR DESCRIPTION
# Description

>Thank you for your contribution !

- enabled automation of the AFD Private Endpoint approval. If you set that parameter to true (default value) there is no need to do a manual step for the Front Door Private Endpoint approval
- removed a feature flag (enableWaf), because it's a best practise to have that on

## Pipeline references
> For module/pipeline changes, please create and attach the status badge of your successful run.

| Pipeline |
| - |
| |

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update to documentation

# Checklist

- [ X ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ X ] My code follows the style guidelines of this project
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have made corresponding changes to the documentation (readme)
- [ X ] I did format my code