### PR TITLE
fix diagnotics changes

### DIFF
--- a/scenarios/secure-baseline-multitenant/azure-resource-manager/main.json
+++ b/scenarios/secure-baseline-multitenant/azure-resource-manager/main.json
@@ -4,18 +4,18 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.17.1.54307",
-      "templateHash": "15757305463107983899"
+      "version": "0.20.4.51522",
+      "templateHash": "14977110681381139912"
     }
   },
   "parameters": {
     "workloadName": {
       "type": "string",
       "defaultValue": "[format('appsvc{0}', take(uniqueString(subscription().id), 4))]",
+      "maxLength": 10,
       "metadata": {
         "description": "suffix (max 10 characters long) that will be used to name the resources in a pattern like <resourceAbbreviation>-<workloadName>"
-      },
-      "maxLength": 10
+      }
     },
     "location": {
       "type": "string",
@@ -330,8 +330,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.17.1.54307",
-              "templateHash": "9105389791545313673"
+              "version": "0.20.4.51522",
+              "templateHash": "1979265534967934369"
             }
           },
           "parameters": {
@@ -1503,8 +1503,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.17.1.54307",
-              "templateHash": "5647597518375120293"
+              "version": "0.20.4.51522",
+              "templateHash": "12984224661558000879"
             }
           },
           "parameters": {
@@ -1899,15 +1899,15 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "10598031696640381029"
+                      "version": "0.20.4.51522",
+                      "templateHash": "4064709153537522093"
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
-                      "maxLength": 80,
                       "minLength": 2,
+                      "maxLength": 80,
                       "metadata": {
                         "description": "Name of the resource Virtual Network (The name must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens)"
                       }
@@ -2035,8 +2035,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "6201606284384486522"
+                      "version": "0.20.4.51522",
+                      "templateHash": "6389026189341578887"
                     }
                   },
                   "parameters": {
@@ -2145,8 +2145,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "9758115776705728804"
+                              "version": "0.20.4.51522",
+                              "templateHash": "8724449987696627131"
                             }
                           },
                           "parameters": {
@@ -2339,15 +2339,15 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "12368266901679986884"
+                      "version": "0.20.4.51522",
+                      "templateHash": "11535560972989472774"
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
                       "minLength": 4,
+                      "maxLength": 63,
                       "metadata": {
                         "description": "Required. Name of the Log Analytics Workspace Service. It must be between 4 and 63 characters and can contain only letters, numbers and \"-\". The \"-\" should not be the first or the last symbol"
                       }
@@ -2378,8 +2378,8 @@
                     "dataRetention": {
                       "type": "int",
                       "defaultValue": 90,
-                      "maxValue": 730,
                       "minValue": 0,
+                      "maxValue": 730,
                       "metadata": {
                         "description": "Optional, default 90. Number of days data will be retained for."
                       }
@@ -2496,8 +2496,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "16272670385761547337"
+                      "version": "0.20.4.51522",
+                      "templateHash": "15323422695799345105"
                     }
                   },
                   "parameters": {
@@ -2570,14 +2570,14 @@
                     "threatIntelMode": {
                       "type": "string",
                       "defaultValue": "Deny",
-                      "metadata": {
-                        "description": "Optional. The operation mode for Threat Intel."
-                      },
                       "allowedValues": [
                         "Alert",
                         "Deny",
                         "Off"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. The operation mode for Threat Intel."
+                      }
                     },
                     "zones": {
                       "type": "array",
@@ -2598,15 +2598,6 @@
                       "defaultValue": "",
                       "metadata": {
                         "description": "Optional. Log Analytics workspace resource identifier."
-                      }
-                    },
-                    "diagnosticLogsRetentionInDays": {
-                      "type": "int",
-                      "defaultValue": 365,
-                      "maxValue": 365,
-                      "minValue": 0,
-                      "metadata": {
-                        "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                       }
                     },
                     "diagnosticEventHubAuthorizationRuleId": {
@@ -2665,11 +2656,7 @@
                         "count": "[length(filter(parameters('diagnosticLogCategoriesToEnable'), lambda('item', not(equals(lambdaVariables('item'), 'allLogs')))))]",
                         "input": {
                           "category": "[filter(parameters('diagnosticLogCategoriesToEnable'), lambda('item', not(equals(lambdaVariables('item'), 'allLogs'))))[copyIndex('diagnosticsLogsSpecified')]]",
-                          "enabled": true,
-                          "retentionPolicy": {
-                            "enabled": true,
-                            "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                          }
+                          "enabled": true
                         }
                       },
                       {
@@ -2678,18 +2665,14 @@
                         "input": {
                           "category": "[parameters('diagnosticMetricsToEnable')[copyIndex('diagnosticsMetrics')]]",
                           "timeGrain": null,
-                          "enabled": true,
-                          "retentionPolicy": {
-                            "enabled": true,
-                            "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                          }
+                          "enabled": true
                         }
                       }
                     ],
                     "azFwNameMaxLength": 56,
                     "azFwNameSantized": "[if(greater(length(parameters('name')), variables('azFwNameMaxLength')), substring(parameters('name'), 0, variables('azFwNameMaxLength')), parameters('name'))]",
                     "azureSkuName": "AZFW_VNet",
-                    "diagnosticsLogs": "[if(contains(parameters('diagnosticLogCategoriesToEnable'), 'allLogs'), createArray(createObject('categoryGroup', 'allLogs', 'enabled', true(), 'retentionPolicy', createObject('enabled', true(), 'days', parameters('diagnosticLogsRetentionInDays')))), variables('diagnosticsLogsSpecified'))]"
+                    "diagnosticsLogs": "[if(contains(parameters('diagnosticLogCategoriesToEnable'), 'allLogs'), createArray(createObject('categoryGroup', 'allLogs', 'enabled', true())), variables('diagnosticsLogsSpecified'))]"
                   },
                   "resources": [
                     {
@@ -2777,8 +2760,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "9758115776705728804"
+                              "version": "0.20.4.51522",
+                              "templateHash": "8724449987696627131"
                             }
                           },
                           "parameters": {
@@ -3117,8 +3100,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.17.1.54307",
-              "templateHash": "15597731126636010887"
+              "version": "0.20.4.51522",
+              "templateHash": "1518181767354561309"
             }
           },
           "parameters": {
@@ -3421,15 +3404,15 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "10598031696640381029"
+                      "version": "0.20.4.51522",
+                      "templateHash": "4064709153537522093"
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
-                      "maxLength": 80,
                       "minLength": 2,
+                      "maxLength": 80,
                       "metadata": {
                         "description": "Name of the resource Virtual Network (The name must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens)"
                       }
@@ -3558,8 +3541,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "16318526785325373726"
+                      "version": "0.20.4.51522",
+                      "templateHash": "2580239868289231046"
                     }
                   },
                   "parameters": {
@@ -3670,15 +3653,15 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "12368266901679986884"
+                      "version": "0.20.4.51522",
+                      "templateHash": "11535560972989472774"
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
                       "minLength": 4,
+                      "maxLength": 63,
                       "metadata": {
                         "description": "Required. Name of the Log Analytics Workspace Service. It must be between 4 and 63 characters and can contain only letters, numbers and \"-\". The \"-\" should not be the first or the last symbol"
                       }
@@ -3709,8 +3692,8 @@
                     "dataRetention": {
                       "type": "int",
                       "defaultValue": 90,
-                      "maxValue": 730,
                       "minValue": 0,
+                      "maxValue": 730,
                       "metadata": {
                         "description": "Optional, default 90. Number of days data will be retained for."
                       }
@@ -3835,8 +3818,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "18167978876521385399"
+                      "version": "0.20.4.51522",
+                      "templateHash": "17746697918973691672"
                     }
                   },
                   "parameters": {
@@ -3917,8 +3900,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "4337185038207822605"
+                              "version": "0.20.4.51522",
+                              "templateHash": "351369789614429753"
                             }
                           },
                           "parameters": {
@@ -4080,8 +4063,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "698709463730837083"
+                              "version": "0.20.4.51522",
+                              "templateHash": "5362294501967708784"
                             }
                           },
                           "parameters": {
@@ -4209,15 +4192,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "14445154365330656192"
+                              "version": "0.20.4.51522",
+                              "templateHash": "16757856721763746334"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 64,
                               "minLength": 2,
+                              "maxLength": 64,
                               "metadata": {
                                 "description": "Required. Name of your pruvate endpoint. Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens."
                               }
@@ -4402,15 +4385,15 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "18367502449983650133"
+                      "version": "0.20.4.51522",
+                      "templateHash": "960377053318251904"
                     }
                   },
                   "parameters": {
                     "appServicePlanName": {
                       "type": "string",
-                      "maxLength": 40,
                       "minLength": 1,
+                      "maxLength": 40,
                       "metadata": {
                         "description": "Required. Name of the App Service Plan."
                       }
@@ -4424,16 +4407,16 @@
                     },
                     "managedIdentityName": {
                       "type": "string",
-                      "maxLength": 128,
                       "minLength": 3,
+                      "maxLength": 128,
                       "metadata": {
                         "description": "Required. Name of the managed Identity that will be assigned to the web app."
                       }
                     },
                     "appConfigurationName": {
                       "type": "string",
-                      "maxLength": 50,
                       "minLength": 5,
+                      "maxLength": 50,
                       "metadata": {
                         "description": "Required. Name of the Azure App Configuration. Alphanumerics, underscores, and hyphens. Must be unique"
                       }
@@ -4589,8 +4572,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "5493405942198387733"
+                              "version": "0.20.4.51522",
+                              "templateHash": "6964356398637818331"
                             }
                           },
                           "parameters": {
@@ -4660,8 +4643,8 @@
                             "samplingPercentage": {
                               "type": "int",
                               "defaultValue": 100,
-                              "maxValue": 100,
                               "minValue": 0,
+                              "maxValue": 100,
                               "metadata": {
                                 "description": "Optional. Percentage of the data produced by the application being monitored that is being sampled for Application Insights telemetry."
                               }
@@ -4779,15 +4762,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "8203858587180465886"
+                              "version": "0.20.4.51522",
+                              "templateHash": "16499077276740623926"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 40,
                               "minLength": 1,
+                              "maxLength": 40,
                               "metadata": {
                                 "description": "Required. The name of the app service plan to deploy."
                               }
@@ -4876,15 +4859,6 @@
                                 "description": "Optional. The name of the diagnostic setting, if deployed."
                               }
                             },
-                            "diagnosticLogsRetentionInDays": {
-                              "type": "int",
-                              "defaultValue": 365,
-                              "maxValue": 365,
-                              "minValue": 0,
-                              "metadata": {
-                                "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
-                              }
-                            },
                             "diagnosticWorkspaceId": {
                               "type": "string",
                               "defaultValue": "",
@@ -4913,11 +4887,7 @@
                                 "input": {
                                   "category": "[parameters('diagnosticMetricsToEnable')[copyIndex('diagnosticsMetrics')]]",
                                   "timeGrain": null,
-                                  "enabled": true,
-                                  "retentionPolicy": {
-                                    "enabled": true,
-                                    "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                                  }
+                                  "enabled": true
                                 }
                               }
                             ],
@@ -5160,17 +5130,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "14737079603874479965"
+                              "version": "0.20.4.51522",
+                              "templateHash": "4151561885012978576"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
+                              "maxLength": 60,
                               "metadata": {
                                 "description": "Required. Name of the site."
-                              },
-                              "maxLength": 60
+                              }
                             },
                             "location": {
                               "type": "string",
@@ -5255,9 +5225,6 @@
                             },
                             "siteConfigSelection": {
                               "type": "string",
-                              "metadata": {
-                                "description": "Mandatory. Predefined set of config settings."
-                              },
                               "allowedValues": [
                                 "windowsNet6",
                                 "windowsNet7",
@@ -5266,7 +5233,10 @@
                                 "linuxNet7",
                                 "linuxNet6",
                                 "linuxNode18"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Mandatory. Predefined set of config settings."
+                              }
                             },
                             "storageAccountId": {
                               "type": "string",
@@ -5308,15 +5278,6 @@
                               "defaultValue": {},
                               "metadata": {
                                 "description": "Optional. Tags of the resource."
-                              }
-                            },
-                            "diagnosticLogsRetentionInDays": {
-                              "type": "int",
-                              "defaultValue": 365,
-                              "maxValue": 365,
-                              "minValue": 0,
-                              "metadata": {
-                                "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
                             },
                             "diagnosticWorkspaceId": {
@@ -5425,11 +5386,7 @@
                                 "count": "[length(filter(parameters('diagnosticLogCategoriesToEnable'), lambda('item', not(equals(lambdaVariables('item'), 'allLogs')))))]",
                                 "input": {
                                   "category": "[filter(parameters('diagnosticLogCategoriesToEnable'), lambda('item', not(equals(lambdaVariables('item'), 'allLogs'))))[copyIndex('diagnosticsLogsSpecified')]]",
-                                  "enabled": true,
-                                  "retentionPolicy": {
-                                    "enabled": true,
-                                    "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                                  }
+                                  "enabled": true
                                 }
                               },
                               {
@@ -5438,15 +5395,11 @@
                                 "input": {
                                   "category": "[parameters('diagnosticMetricsToEnable')[copyIndex('diagnosticsMetrics')]]",
                                   "timeGrain": null,
-                                  "enabled": true,
-                                  "retentionPolicy": {
-                                    "enabled": true,
-                                    "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                                  }
+                                  "enabled": true
                                 }
                               }
                             ],
-                            "diagnosticsLogs": "[if(contains(parameters('diagnosticLogCategoriesToEnable'), 'allLogs'), createArray(createObject('categoryGroup', 'allLogs', 'enabled', true(), 'retentionPolicy', createObject('enabled', true(), 'days', parameters('diagnosticLogsRetentionInDays')))), variables('diagnosticsLogsSpecified'))]",
+                            "diagnosticsLogs": "[if(contains(parameters('diagnosticLogCategoriesToEnable'), 'allLogs'), createArray(createObject('categoryGroup', 'allLogs', 'enabled', true())), variables('diagnosticsLogsSpecified'))]",
                             "identityType": "[if(parameters('systemAssignedIdentity'), if(not(empty(parameters('userAssignedIdentities'))), 'SystemAssigned,UserAssigned', 'SystemAssigned'), if(not(empty(parameters('userAssignedIdentities'))), 'UserAssigned', 'None'))]",
                             "identity": "[if(not(equals(variables('identityType'), 'None')), createObject('type', variables('identityType'), 'userAssignedIdentities', if(not(empty(parameters('userAssignedIdentities'))), parameters('userAssignedIdentities'), null())), null())]",
                             "webapp_dns_name": ".azurewebsites.net",
@@ -5597,8 +5550,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.17.1.54307",
-                                      "templateHash": "14165506043480703418"
+                                      "version": "0.20.4.51522",
+                                      "templateHash": "4678926577241725449"
                                     }
                                   },
                                   "parameters": {
@@ -5731,7 +5684,6 @@
                                   "storageAccountId": "[if(contains(parameters('slots')[copyIndex()], 'storageAccountId'), createObject('value', parameters('slots')[copyIndex()].storageAccountId), createObject('value', parameters('storageAccountId')))]",
                                   "appInsightId": "[if(contains(parameters('slots')[copyIndex()], 'appInsightId'), createObject('value', parameters('slots')[copyIndex()].appInsightId), createObject('value', parameters('appInsightId')))]",
                                   "setAzureWebJobsDashboard": "[if(contains(parameters('slots')[copyIndex()], 'setAzureWebJobsDashboard'), createObject('value', parameters('slots')[copyIndex()].setAzureWebJobsDashboard), createObject('value', parameters('setAzureWebJobsDashboard')))]",
-                                  "diagnosticLogsRetentionInDays": "[if(contains(parameters('slots')[copyIndex()], 'diagnosticLogsRetentionInDays'), createObject('value', parameters('slots')[copyIndex()].diagnosticLogsRetentionInDays), createObject('value', parameters('diagnosticLogsRetentionInDays')))]",
                                   "diagnosticWorkspaceId": {
                                     "value": "[parameters('diagnosticWorkspaceId')]"
                                   },
@@ -5758,8 +5710,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.17.1.54307",
-                                      "templateHash": "4018853689576160044"
+                                      "version": "0.20.4.51522",
+                                      "templateHash": "17610178805028045872"
                                     }
                                   },
                                   "parameters": {
@@ -5900,15 +5852,6 @@
                                         "description": "Optional. Tags of the resource."
                                       }
                                     },
-                                    "diagnosticLogsRetentionInDays": {
-                                      "type": "int",
-                                      "defaultValue": 365,
-                                      "maxValue": 365,
-                                      "minValue": 0,
-                                      "metadata": {
-                                        "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
-                                      }
-                                    },
                                     "diagnosticWorkspaceId": {
                                       "type": "string",
                                       "defaultValue": "",
@@ -6041,11 +5984,7 @@
                                         "count": "[length(parameters('diagnosticLogCategoriesToEnable'))]",
                                         "input": {
                                           "category": "[parameters('diagnosticLogCategoriesToEnable')[copyIndex('diagnosticsLogs')]]",
-                                          "enabled": true,
-                                          "retentionPolicy": {
-                                            "enabled": true,
-                                            "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                                          }
+                                          "enabled": true
                                         }
                                       },
                                       {
@@ -6054,11 +5993,7 @@
                                         "input": {
                                           "category": "[parameters('diagnosticMetricsToEnable')[copyIndex('diagnosticsMetrics')]]",
                                           "timeGrain": null,
-                                          "enabled": true,
-                                          "retentionPolicy": {
-                                            "enabled": true,
-                                            "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                                          }
+                                          "enabled": true
                                         }
                                       }
                                     ],
@@ -6156,8 +6091,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.17.1.54307",
-                                              "templateHash": "15599280375124632122"
+                                              "version": "0.20.4.51522",
+                                              "templateHash": "12141117254902367852"
                                             }
                                           },
                                           "parameters": {
@@ -6392,15 +6327,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "18120221178179977349"
+                              "version": "0.20.4.51522",
+                              "templateHash": "16624770513957439457"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 128,
                               "minLength": 3,
+                              "maxLength": 128,
                               "metadata": {
                                 "description": "Required. The name of the user assigned managed Identity. 3-128, can contain \"-\" and \"_\""
                               }
@@ -6504,8 +6439,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "698709463730837083"
+                              "version": "0.20.4.51522",
+                              "templateHash": "5362294501967708784"
                             }
                           },
                           "parameters": {
@@ -6633,15 +6568,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "14445154365330656192"
+                              "version": "0.20.4.51522",
+                              "templateHash": "16757856721763746334"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 64,
                               "minLength": 2,
+                              "maxLength": 64,
                               "metadata": {
                                 "description": "Required. Name of your pruvate endpoint. Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens."
                               }
@@ -6773,15 +6708,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "14445154365330656192"
+                              "version": "0.20.4.51522",
+                              "templateHash": "16757856721763746334"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 64,
                               "minLength": 2,
+                              "maxLength": 64,
                               "metadata": {
                                 "description": "Required. Name of your pruvate endpoint. Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens."
                               }
@@ -6907,18 +6842,18 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "9895518615263357712"
+                              "version": "0.20.4.51522",
+                              "templateHash": "11016487736119141662"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
+                              "minLength": 5,
+                              "maxLength": 50,
                               "metadata": {
                                 "description": "Required. Name of the Azure App Configuration. Alphanumerics, underscores, and hyphens"
-                              },
-                              "maxLength": 50,
-                              "minLength": 5
+                              }
                             },
                             "location": {
                               "type": "string",
@@ -6950,13 +6885,13 @@
                             "sku": {
                               "type": "string",
                               "defaultValue": "Standard",
-                              "metadata": {
-                                "description": "Optional. Pricing tier of App Configuration."
-                              },
                               "allowedValues": [
                                 "Free",
                                 "Standard"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional. Pricing tier of App Configuration."
+                              }
                             },
                             "disableLocalAuth": {
                               "type": "bool",
@@ -6993,8 +6928,8 @@
                             "softDeleteRetentionInDays": {
                               "type": "int",
                               "defaultValue": 7,
-                              "maxValue": 7,
                               "minValue": 1,
+                              "maxValue": 7,
                               "metadata": {
                                 "description": "Optional. The amount of time in days that the configuration store will be retained when it is soft deleted."
                               }
@@ -7095,8 +7030,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "698709463730837083"
+                              "version": "0.20.4.51522",
+                              "templateHash": "5362294501967708784"
                             }
                           },
                           "parameters": {
@@ -7218,15 +7153,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "14445154365330656192"
+                              "version": "0.20.4.51522",
+                              "templateHash": "16757856721763746334"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 64,
                               "minLength": 2,
+                              "maxLength": 64,
                               "metadata": {
                                 "description": "Required. Name of your pruvate endpoint. Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens."
                               }
@@ -7347,8 +7282,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "757317532981319179"
+                              "version": "0.20.4.51522",
+                              "templateHash": "13945851285616680724"
                             }
                           },
                           "parameters": {
@@ -7377,16 +7312,16 @@
                             "principalType": {
                               "type": "string",
                               "defaultValue": "ServicePrincipal",
-                              "metadata": {
-                                "description": "Optional, default ServicePrincipal"
-                              },
                               "allowedValues": [
                                 "ServicePrincipal",
                                 "Device",
                                 "ForeignGroup",
                                 "Group",
                                 "User"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional, default ServicePrincipal"
+                              }
                             },
                             "roledescription": {
                               "type": "string",
@@ -7394,7 +7329,7 @@
                             }
                           },
                           "variables": {
-                            "$fxv#0": "{\r\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n    \"contentVersion\": \"1.0.0.0\",\r\n    \"parameters\": {\r\n        \"scope\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"name\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"roleDefinitionId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalType\": {\r\n            \"type\": \"string\"\r\n        }\r\n    },\r\n    \"resources\": [\r\n        {\r\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\r\n            \"apiVersion\": \"2020-08-01-preview\",\r\n            \"scope\": \"[parameters('scope')]\",\r\n            \"name\": \"[parameters('name')]\",\r\n            \"properties\": {\r\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\r\n                \"principalId\": \"[parameters('principalId')]\",\r\n                \"principalType\": \"[parameters('principalType')]\"\r\n            }\r\n        }\r\n    ],\r\n    \"outputs\": {\r\n        \"roleAssignmentId\": {\r\n            \"type\": \"string\",\r\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\r\n        }\r\n    }\r\n}"
+                            "$fxv#0": "{\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\n    \"contentVersion\": \"1.0.0.0\",\n    \"parameters\": {\n        \"scope\": {\n            \"type\": \"string\"\n        },\n        \"name\": {\n            \"type\": \"string\"\n        },\n        \"roleDefinitionId\": {\n            \"type\": \"string\"\n        },\n        \"principalId\": {\n            \"type\": \"string\"\n        },\n        \"principalType\": {\n            \"type\": \"string\"\n        }\n    },\n    \"resources\": [\n        {\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\n            \"apiVersion\": \"2020-08-01-preview\",\n            \"scope\": \"[parameters('scope')]\",\n            \"name\": \"[parameters('name')]\",\n            \"properties\": {\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\n                \"principalId\": \"[parameters('principalId')]\",\n                \"principalType\": \"[parameters('principalType')]\"\n            }\n        }\n    ],\n    \"outputs\": {\n        \"roleAssignmentId\": {\n            \"type\": \"string\",\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\n        }\n    }\n}"
                           },
                           "resources": [
                             {
@@ -7473,8 +7408,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "757317532981319179"
+                              "version": "0.20.4.51522",
+                              "templateHash": "13945851285616680724"
                             }
                           },
                           "parameters": {
@@ -7503,16 +7438,16 @@
                             "principalType": {
                               "type": "string",
                               "defaultValue": "ServicePrincipal",
-                              "metadata": {
-                                "description": "Optional, default ServicePrincipal"
-                              },
                               "allowedValues": [
                                 "ServicePrincipal",
                                 "Device",
                                 "ForeignGroup",
                                 "Group",
                                 "User"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional, default ServicePrincipal"
+                              }
                             },
                             "roledescription": {
                               "type": "string",
@@ -7520,7 +7455,7 @@
                             }
                           },
                           "variables": {
-                            "$fxv#0": "{\r\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n    \"contentVersion\": \"1.0.0.0\",\r\n    \"parameters\": {\r\n        \"scope\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"name\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"roleDefinitionId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalType\": {\r\n            \"type\": \"string\"\r\n        }\r\n    },\r\n    \"resources\": [\r\n        {\r\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\r\n            \"apiVersion\": \"2020-08-01-preview\",\r\n            \"scope\": \"[parameters('scope')]\",\r\n            \"name\": \"[parameters('name')]\",\r\n            \"properties\": {\r\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\r\n                \"principalId\": \"[parameters('principalId')]\",\r\n                \"principalType\": \"[parameters('principalType')]\"\r\n            }\r\n        }\r\n    ],\r\n    \"outputs\": {\r\n        \"roleAssignmentId\": {\r\n            \"type\": \"string\",\r\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\r\n        }\r\n    }\r\n}"
+                            "$fxv#0": "{\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\n    \"contentVersion\": \"1.0.0.0\",\n    \"parameters\": {\n        \"scope\": {\n            \"type\": \"string\"\n        },\n        \"name\": {\n            \"type\": \"string\"\n        },\n        \"roleDefinitionId\": {\n            \"type\": \"string\"\n        },\n        \"principalId\": {\n            \"type\": \"string\"\n        },\n        \"principalType\": {\n            \"type\": \"string\"\n        }\n    },\n    \"resources\": [\n        {\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\n            \"apiVersion\": \"2020-08-01-preview\",\n            \"scope\": \"[parameters('scope')]\",\n            \"name\": \"[parameters('name')]\",\n            \"properties\": {\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\n                \"principalId\": \"[parameters('principalId')]\",\n                \"principalType\": \"[parameters('principalType')]\"\n            }\n        }\n    ],\n    \"outputs\": {\n        \"roleAssignmentId\": {\n            \"type\": \"string\",\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\n        }\n    }\n}"
                           },
                           "resources": [
                             {
@@ -7597,8 +7532,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "757317532981319179"
+                              "version": "0.20.4.51522",
+                              "templateHash": "13945851285616680724"
                             }
                           },
                           "parameters": {
@@ -7627,16 +7562,16 @@
                             "principalType": {
                               "type": "string",
                               "defaultValue": "ServicePrincipal",
-                              "metadata": {
-                                "description": "Optional, default ServicePrincipal"
-                              },
                               "allowedValues": [
                                 "ServicePrincipal",
                                 "Device",
                                 "ForeignGroup",
                                 "Group",
                                 "User"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional, default ServicePrincipal"
+                              }
                             },
                             "roledescription": {
                               "type": "string",
@@ -7644,7 +7579,7 @@
                             }
                           },
                           "variables": {
-                            "$fxv#0": "{\r\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n    \"contentVersion\": \"1.0.0.0\",\r\n    \"parameters\": {\r\n        \"scope\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"name\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"roleDefinitionId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalType\": {\r\n            \"type\": \"string\"\r\n        }\r\n    },\r\n    \"resources\": [\r\n        {\r\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\r\n            \"apiVersion\": \"2020-08-01-preview\",\r\n            \"scope\": \"[parameters('scope')]\",\r\n            \"name\": \"[parameters('name')]\",\r\n            \"properties\": {\r\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\r\n                \"principalId\": \"[parameters('principalId')]\",\r\n                \"principalType\": \"[parameters('principalType')]\"\r\n            }\r\n        }\r\n    ],\r\n    \"outputs\": {\r\n        \"roleAssignmentId\": {\r\n            \"type\": \"string\",\r\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\r\n        }\r\n    }\r\n}"
+                            "$fxv#0": "{\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\n    \"contentVersion\": \"1.0.0.0\",\n    \"parameters\": {\n        \"scope\": {\n            \"type\": \"string\"\n        },\n        \"name\": {\n            \"type\": \"string\"\n        },\n        \"roleDefinitionId\": {\n            \"type\": \"string\"\n        },\n        \"principalId\": {\n            \"type\": \"string\"\n        },\n        \"principalType\": {\n            \"type\": \"string\"\n        }\n    },\n    \"resources\": [\n        {\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\n            \"apiVersion\": \"2020-08-01-preview\",\n            \"scope\": \"[parameters('scope')]\",\n            \"name\": \"[parameters('name')]\",\n            \"properties\": {\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\n                \"principalId\": \"[parameters('principalId')]\",\n                \"principalType\": \"[parameters('principalType')]\"\n            }\n        }\n    ],\n    \"outputs\": {\n        \"roleAssignmentId\": {\n            \"type\": \"string\",\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\n        }\n    }\n}"
                           },
                           "resources": [
                             {
@@ -7723,8 +7658,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "757317532981319179"
+                              "version": "0.20.4.51522",
+                              "templateHash": "13945851285616680724"
                             }
                           },
                           "parameters": {
@@ -7753,16 +7688,16 @@
                             "principalType": {
                               "type": "string",
                               "defaultValue": "ServicePrincipal",
-                              "metadata": {
-                                "description": "Optional, default ServicePrincipal"
-                              },
                               "allowedValues": [
                                 "ServicePrincipal",
                                 "Device",
                                 "ForeignGroup",
                                 "Group",
                                 "User"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional, default ServicePrincipal"
+                              }
                             },
                             "roledescription": {
                               "type": "string",
@@ -7770,7 +7705,7 @@
                             }
                           },
                           "variables": {
-                            "$fxv#0": "{\r\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n    \"contentVersion\": \"1.0.0.0\",\r\n    \"parameters\": {\r\n        \"scope\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"name\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"roleDefinitionId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalType\": {\r\n            \"type\": \"string\"\r\n        }\r\n    },\r\n    \"resources\": [\r\n        {\r\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\r\n            \"apiVersion\": \"2020-08-01-preview\",\r\n            \"scope\": \"[parameters('scope')]\",\r\n            \"name\": \"[parameters('name')]\",\r\n            \"properties\": {\r\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\r\n                \"principalId\": \"[parameters('principalId')]\",\r\n                \"principalType\": \"[parameters('principalType')]\"\r\n            }\r\n        }\r\n    ],\r\n    \"outputs\": {\r\n        \"roleAssignmentId\": {\r\n            \"type\": \"string\",\r\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\r\n        }\r\n    }\r\n}"
+                            "$fxv#0": "{\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\n    \"contentVersion\": \"1.0.0.0\",\n    \"parameters\": {\n        \"scope\": {\n            \"type\": \"string\"\n        },\n        \"name\": {\n            \"type\": \"string\"\n        },\n        \"roleDefinitionId\": {\n            \"type\": \"string\"\n        },\n        \"principalId\": {\n            \"type\": \"string\"\n        },\n        \"principalType\": {\n            \"type\": \"string\"\n        }\n    },\n    \"resources\": [\n        {\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\n            \"apiVersion\": \"2020-08-01-preview\",\n            \"scope\": \"[parameters('scope')]\",\n            \"name\": \"[parameters('name')]\",\n            \"properties\": {\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\n                \"principalId\": \"[parameters('principalId')]\",\n                \"principalType\": \"[parameters('principalType')]\"\n            }\n        }\n    ],\n    \"outputs\": {\n        \"roleAssignmentId\": {\n            \"type\": \"string\",\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\n        }\n    }\n}"
                           },
                           "resources": [
                             {
@@ -7909,8 +7844,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "13232520068507076660"
+                      "version": "0.20.4.51522",
+                      "templateHash": "15774402054966915173"
                     }
                   },
                   "parameters": {
@@ -7929,13 +7864,13 @@
                     "endpointEnabled": {
                       "type": "string",
                       "defaultValue": "Enabled",
-                      "metadata": {
-                        "description": "AFD Endpoint State"
-                      },
                       "allowedValues": [
                         "Enabled",
                         "Disabled"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "AFD Endpoint State"
+                      }
                     },
                     "tags": {
                       "type": "object",
@@ -7946,13 +7881,13 @@
                     },
                     "skuName": {
                       "type": "string",
-                      "metadata": {
-                        "description": "Required. The pricing tier (defines a CDN provider, feature list and rate) of the CDN profile."
-                      },
                       "allowedValues": [
                         "Standard_AzureFrontDoor",
                         "Premium_AzureFrontDoor"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Required. The pricing tier (defines a CDN provider, feature list and rate) of the CDN profile."
+                      }
                     },
                     "originGroupName": {
                       "type": "string",
@@ -8017,15 +7952,6 @@
                         "description": "if no diagnostic serttings are required, provide an empty string. Resource ID of log analytics workspace."
                       }
                     },
-                    "diagnosticLogsRetentionInDays": {
-                      "type": "int",
-                      "defaultValue": 365,
-                      "maxValue": 365,
-                      "minValue": 0,
-                      "metadata": {
-                        "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
-                      }
-                    },
                     "diagnosticLogCategoriesToEnable": {
                       "type": "array",
                       "defaultValue": [
@@ -8068,11 +7994,7 @@
                         "count": "[length(filter(parameters('diagnosticLogCategoriesToEnable'), lambda('item', not(equals(lambdaVariables('item'), 'allLogs')))))]",
                         "input": {
                           "category": "[filter(parameters('diagnosticLogCategoriesToEnable'), lambda('item', not(equals(lambdaVariables('item'), 'allLogs'))))[copyIndex('diagnosticsLogsSpecified')]]",
-                          "enabled": true,
-                          "retentionPolicy": {
-                            "enabled": true,
-                            "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                          }
+                          "enabled": true
                         }
                       },
                       {
@@ -8081,11 +8003,7 @@
                         "input": {
                           "category": "[parameters('diagnosticMetricsToEnable')[copyIndex('diagnosticsMetrics')]]",
                           "timeGrain": null,
-                          "enabled": true,
-                          "retentionPolicy": {
-                            "enabled": true,
-                            "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                          }
+                          "enabled": true
                         }
                       }
                     ],
@@ -8137,7 +8055,7 @@
                       "text/x-component",
                       "text/x-java-source"
                     ],
-                    "diagnosticsLogs": "[if(contains(parameters('diagnosticLogCategoriesToEnable'), 'allLogs'), createArray(createObject('categoryGroup', 'allLogs', 'enabled', true(), 'retentionPolicy', createObject('enabled', true(), 'days', parameters('diagnosticLogsRetentionInDays')))), variables('diagnosticsLogsSpecified'))]"
+                    "diagnosticsLogs": "[if(contains(parameters('diagnosticLogCategoriesToEnable'), 'allLogs'), createArray(createObject('categoryGroup', 'allLogs', 'enabled', true())), variables('diagnosticsLogsSpecified'))]"
                   },
                   "resources": [
                     {
@@ -8410,8 +8328,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "6324920352926996485"
+                      "version": "0.20.4.51522",
+                      "templateHash": "9443579810642006669"
                     }
                   },
                   "parameters": {
@@ -8580,26 +8498,26 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "2982997895193326464"
+                      "version": "0.20.4.51522",
+                      "templateHash": "13533098897900792860"
                     }
                   },
                   "parameters": {
                     "vmWindowsJumpboxName": {
                       "type": "string",
-                      "maxLength": 64,
                       "minLength": 2,
+                      "maxLength": 64,
                       "metadata": {
                         "description": "Required. Name of windows VM."
                       }
                     },
                     "vmJumpHostUserAssignedManagedIdentityName": {
                       "type": "string",
+                      "minLength": 3,
+                      "maxLength": 128,
                       "metadata": {
                         "description": "Required. Name of the vmJumpHostUserAssignedManagedIdenity."
-                      },
-                      "maxLength": 128,
-                      "minLength": 3
+                      }
                     },
                     "adminUsername": {
                       "type": "string",
@@ -8748,15 +8666,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "16379613978965958962"
+                              "version": "0.20.4.51522",
+                              "templateHash": "831346153285897056"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 64,
                               "minLength": 2,
+                              "maxLength": 64,
                               "metadata": {
                                 "description": "Name of the resource Virtual Network (The name must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens)"
                               }
@@ -8970,7 +8888,7 @@
                                 "autoUpgradeMinorVersion": true,
                                 "settings": {
                                   "fileUris": [
-                                    "https://raw.githubusercontent.com/thotheod/appservice-landing-zone-accelerator/fix/02-AutoApprovalAfdPe/scenarios/shared/scripts/win-devops-vm-extensions/post-deployment.ps1"
+                                    "https://raw.githubusercontent.com/Azure/appservice-landing-zone-accelerator/main/scenarios/shared/scripts/win-devops-vm-extensions/post-deployment.ps1"
                                   ]
                                 },
                                 "protectedSettings": {
@@ -9010,8 +8928,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.17.1.54307",
-                                      "templateHash": "10954988008367803769"
+                                      "version": "0.20.4.51522",
+                                      "templateHash": "4541805467666285522"
                                     }
                                   },
                                   "parameters": {
@@ -9149,15 +9067,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "18120221178179977349"
+                              "version": "0.20.4.51522",
+                              "templateHash": "16624770513957439457"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 128,
                               "minLength": 3,
+                              "maxLength": 128,
                               "metadata": {
                                 "description": "Required. The name of the user assigned managed Identity. 3-128, can contain \"-\" and \"_\""
                               }
@@ -9261,8 +9179,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "757317532981319179"
+                              "version": "0.20.4.51522",
+                              "templateHash": "13945851285616680724"
                             }
                           },
                           "parameters": {
@@ -9291,16 +9209,16 @@
                             "principalType": {
                               "type": "string",
                               "defaultValue": "ServicePrincipal",
-                              "metadata": {
-                                "description": "Optional, default ServicePrincipal"
-                              },
                               "allowedValues": [
                                 "ServicePrincipal",
                                 "Device",
                                 "ForeignGroup",
                                 "Group",
                                 "User"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional, default ServicePrincipal"
+                              }
                             },
                             "roledescription": {
                               "type": "string",
@@ -9308,7 +9226,7 @@
                             }
                           },
                           "variables": {
-                            "$fxv#0": "{\r\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n    \"contentVersion\": \"1.0.0.0\",\r\n    \"parameters\": {\r\n        \"scope\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"name\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"roleDefinitionId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalType\": {\r\n            \"type\": \"string\"\r\n        }\r\n    },\r\n    \"resources\": [\r\n        {\r\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\r\n            \"apiVersion\": \"2020-08-01-preview\",\r\n            \"scope\": \"[parameters('scope')]\",\r\n            \"name\": \"[parameters('name')]\",\r\n            \"properties\": {\r\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\r\n                \"principalId\": \"[parameters('principalId')]\",\r\n                \"principalType\": \"[parameters('principalType')]\"\r\n            }\r\n        }\r\n    ],\r\n    \"outputs\": {\r\n        \"roleAssignmentId\": {\r\n            \"type\": \"string\",\r\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\r\n        }\r\n    }\r\n}"
+                            "$fxv#0": "{\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\n    \"contentVersion\": \"1.0.0.0\",\n    \"parameters\": {\n        \"scope\": {\n            \"type\": \"string\"\n        },\n        \"name\": {\n            \"type\": \"string\"\n        },\n        \"roleDefinitionId\": {\n            \"type\": \"string\"\n        },\n        \"principalId\": {\n            \"type\": \"string\"\n        },\n        \"principalType\": {\n            \"type\": \"string\"\n        }\n    },\n    \"resources\": [\n        {\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\n            \"apiVersion\": \"2020-08-01-preview\",\n            \"scope\": \"[parameters('scope')]\",\n            \"name\": \"[parameters('name')]\",\n            \"properties\": {\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\n                \"principalId\": \"[parameters('principalId')]\",\n                \"principalType\": \"[parameters('principalType')]\"\n            }\n        }\n    ],\n    \"outputs\": {\n        \"roleAssignmentId\": {\n            \"type\": \"string\",\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\n        }\n    }\n}"
                           },
                           "resources": [
                             {
@@ -9386,8 +9304,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "757317532981319179"
+                              "version": "0.20.4.51522",
+                              "templateHash": "13945851285616680724"
                             }
                           },
                           "parameters": {
@@ -9416,16 +9334,16 @@
                             "principalType": {
                               "type": "string",
                               "defaultValue": "ServicePrincipal",
-                              "metadata": {
-                                "description": "Optional, default ServicePrincipal"
-                              },
                               "allowedValues": [
                                 "ServicePrincipal",
                                 "Device",
                                 "ForeignGroup",
                                 "Group",
                                 "User"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional, default ServicePrincipal"
+                              }
                             },
                             "roledescription": {
                               "type": "string",
@@ -9433,7 +9351,7 @@
                             }
                           },
                           "variables": {
-                            "$fxv#0": "{\r\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n    \"contentVersion\": \"1.0.0.0\",\r\n    \"parameters\": {\r\n        \"scope\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"name\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"roleDefinitionId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalType\": {\r\n            \"type\": \"string\"\r\n        }\r\n    },\r\n    \"resources\": [\r\n        {\r\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\r\n            \"apiVersion\": \"2020-08-01-preview\",\r\n            \"scope\": \"[parameters('scope')]\",\r\n            \"name\": \"[parameters('name')]\",\r\n            \"properties\": {\r\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\r\n                \"principalId\": \"[parameters('principalId')]\",\r\n                \"principalType\": \"[parameters('principalType')]\"\r\n            }\r\n        }\r\n    ],\r\n    \"outputs\": {\r\n        \"roleAssignmentId\": {\r\n            \"type\": \"string\",\r\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\r\n        }\r\n    }\r\n}"
+                            "$fxv#0": "{\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\n    \"contentVersion\": \"1.0.0.0\",\n    \"parameters\": {\n        \"scope\": {\n            \"type\": \"string\"\n        },\n        \"name\": {\n            \"type\": \"string\"\n        },\n        \"roleDefinitionId\": {\n            \"type\": \"string\"\n        },\n        \"principalId\": {\n            \"type\": \"string\"\n        },\n        \"principalType\": {\n            \"type\": \"string\"\n        }\n    },\n    \"resources\": [\n        {\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\n            \"apiVersion\": \"2020-08-01-preview\",\n            \"scope\": \"[parameters('scope')]\",\n            \"name\": \"[parameters('name')]\",\n            \"properties\": {\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\n                \"principalId\": \"[parameters('principalId')]\",\n                \"principalType\": \"[parameters('principalType')]\"\n            }\n        }\n    ],\n    \"outputs\": {\n        \"roleAssignmentId\": {\n            \"type\": \"string\",\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\n        }\n    }\n}"
                           },
                           "resources": [
                             {
@@ -9512,8 +9430,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "757317532981319179"
+                              "version": "0.20.4.51522",
+                              "templateHash": "13945851285616680724"
                             }
                           },
                           "parameters": {
@@ -9542,16 +9460,16 @@
                             "principalType": {
                               "type": "string",
                               "defaultValue": "ServicePrincipal",
-                              "metadata": {
-                                "description": "Optional, default ServicePrincipal"
-                              },
                               "allowedValues": [
                                 "ServicePrincipal",
                                 "Device",
                                 "ForeignGroup",
                                 "Group",
                                 "User"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional, default ServicePrincipal"
+                              }
                             },
                             "roledescription": {
                               "type": "string",
@@ -9559,7 +9477,7 @@
                             }
                           },
                           "variables": {
-                            "$fxv#0": "{\r\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\r\n    \"contentVersion\": \"1.0.0.0\",\r\n    \"parameters\": {\r\n        \"scope\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"name\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"roleDefinitionId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalId\": {\r\n            \"type\": \"string\"\r\n        },\r\n        \"principalType\": {\r\n            \"type\": \"string\"\r\n        }\r\n    },\r\n    \"resources\": [\r\n        {\r\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\r\n            \"apiVersion\": \"2020-08-01-preview\",\r\n            \"scope\": \"[parameters('scope')]\",\r\n            \"name\": \"[parameters('name')]\",\r\n            \"properties\": {\r\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\r\n                \"principalId\": \"[parameters('principalId')]\",\r\n                \"principalType\": \"[parameters('principalType')]\"\r\n            }\r\n        }\r\n    ],\r\n    \"outputs\": {\r\n        \"roleAssignmentId\": {\r\n            \"type\": \"string\",\r\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\r\n        }\r\n    }\r\n}"
+                            "$fxv#0": "{\n    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\",\n    \"contentVersion\": \"1.0.0.0\",\n    \"parameters\": {\n        \"scope\": {\n            \"type\": \"string\"\n        },\n        \"name\": {\n            \"type\": \"string\"\n        },\n        \"roleDefinitionId\": {\n            \"type\": \"string\"\n        },\n        \"principalId\": {\n            \"type\": \"string\"\n        },\n        \"principalType\": {\n            \"type\": \"string\"\n        }\n    },\n    \"resources\": [\n        {\n            \"type\": \"Microsoft.Authorization/roleAssignments\",\n            \"apiVersion\": \"2020-08-01-preview\",\n            \"scope\": \"[parameters('scope')]\",\n            \"name\": \"[parameters('name')]\",\n            \"properties\": {\n                \"roleDefinitionId\": \"[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]\",\n                \"principalId\": \"[parameters('principalId')]\",\n                \"principalType\": \"[parameters('principalType')]\"\n            }\n        }\n    ],\n    \"outputs\": {\n        \"roleAssignmentId\": {\n            \"type\": \"string\",\n            \"value\": \"[extensionResourceId(parameters('scope'), 'Microsoft.Authorization/roleAssignments', parameters('name'))]\"\n        }\n    }\n}"
                           },
                           "resources": [
                             {
@@ -9670,8 +9588,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "6589372805357964201"
+                      "version": "0.20.4.51522",
+                      "templateHash": "10269755258310872269"
                     }
                   },
                   "parameters": {
@@ -9769,8 +9687,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "10925798244505841343"
+                              "version": "0.20.4.51522",
+                              "templateHash": "11733225414564442312"
                             }
                           },
                           "parameters": {
@@ -9819,33 +9737,30 @@
                             "replicasPerMaster": {
                               "type": "int",
                               "defaultValue": 1,
+                              "minValue": 1,
                               "metadata": {
                                 "description": "Optional. The number of replicas to be created per primary."
-                              },
-                              "minValue": 1
+                              }
                             },
                             "replicasPerPrimary": {
                               "type": "int",
                               "defaultValue": 1,
+                              "minValue": 1,
                               "metadata": {
                                 "description": "Optional. The number of replicas to be created per primary."
-                              },
-                              "minValue": 1
+                              }
                             },
                             "shardCount": {
                               "type": "int",
                               "defaultValue": 1,
+                              "minValue": 1,
                               "metadata": {
                                 "description": "Optional. The number of shards to be created on a Premium Cluster Cache."
-                              },
-                              "minValue": 1
+                              }
                             },
                             "capacity": {
                               "type": "int",
                               "defaultValue": 2,
-                              "metadata": {
-                                "description": "Optional. The size of the Redis cache to deploy. Valid values: for C (Basic/Standard) family (0, 1, 2, 3, 4, 5, 6), for P (Premium) family (1, 2, 3, 4)."
-                              },
                               "allowedValues": [
                                 0,
                                 1,
@@ -9854,19 +9769,22 @@
                                 4,
                                 5,
                                 6
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional. The size of the Redis cache to deploy. Valid values: for C (Basic/Standard) family (0, 1, 2, 3, 4, 5, 6), for P (Premium) family (1, 2, 3, 4)."
+                              }
                             },
                             "skuName": {
                               "type": "string",
                               "defaultValue": "Standard",
-                              "metadata": {
-                                "description": "Optional, default is Standard. The type of Redis cache to deploy."
-                              },
                               "allowedValues": [
                                 "Basic",
                                 "Premium",
                                 "Standard"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional, default is Standard. The type of Redis cache to deploy."
+                              }
                             },
                             "subnetId": {
                               "type": "string",
@@ -9880,15 +9798,6 @@
                               "defaultValue": "[format('{0}-diagnosticSettings', parameters('name'))]",
                               "metadata": {
                                 "description": "Optional. The name of the diagnostic setting, if deployed."
-                              }
-                            },
-                            "diagnosticLogsRetentionInDays": {
-                              "type": "int",
-                              "defaultValue": 365,
-                              "maxValue": 365,
-                              "minValue": 0,
-                              "metadata": {
-                                "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
                             },
                             "diagnosticWorkspaceId": {
@@ -9938,11 +9847,7 @@
                                 "count": "[length(filter(parameters('diagnosticLogCategoriesToEnable'), lambda('item', not(equals(lambdaVariables('item'), 'allLogs')))))]",
                                 "input": {
                                   "category": "[filter(parameters('diagnosticLogCategoriesToEnable'), lambda('item', not(equals(lambdaVariables('item'), 'allLogs'))))[copyIndex('diagnosticsLogsSpecified')]]",
-                                  "enabled": true,
-                                  "retentionPolicy": {
-                                    "enabled": true,
-                                    "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                                  }
+                                  "enabled": true
                                 }
                               },
                               {
@@ -9951,15 +9856,11 @@
                                 "input": {
                                   "category": "[parameters('diagnosticMetricsToEnable')[copyIndex('diagnosticsMetrics')]]",
                                   "timeGrain": null,
-                                  "enabled": true,
-                                  "retentionPolicy": {
-                                    "enabled": true,
-                                    "days": "[parameters('diagnosticLogsRetentionInDays')]"
-                                  }
+                                  "enabled": true
                                 }
                               }
                             ],
-                            "diagnosticsLogs": "[if(contains(parameters('diagnosticLogCategoriesToEnable'), 'allLogs'), createArray(createObject('categoryGroup', 'allLogs', 'enabled', true(), 'retentionPolicy', createObject('enabled', true(), 'days', parameters('diagnosticLogsRetentionInDays')))), variables('diagnosticsLogsSpecified'))]"
+                            "diagnosticsLogs": "[if(contains(parameters('diagnosticLogCategoriesToEnable'), 'allLogs'), createArray(createObject('categoryGroup', 'allLogs', 'enabled', true())), variables('diagnosticsLogsSpecified'))]"
                           },
                           "resources": [
                             {
@@ -10106,8 +10007,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "698709463730837083"
+                              "version": "0.20.4.51522",
+                              "templateHash": "5362294501967708784"
                             }
                           },
                           "parameters": {
@@ -10235,15 +10136,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "14445154365330656192"
+                              "version": "0.20.4.51522",
+                              "templateHash": "16757856721763746334"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 64,
                               "minLength": 2,
+                              "maxLength": 64,
                               "metadata": {
                                 "description": "Required. Name of your pruvate endpoint. Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens."
                               }
@@ -10448,8 +10349,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "14050016351388336452"
+                      "version": "0.20.4.51522",
+                      "templateHash": "13964324975529071265"
                     }
                   },
                   "parameters": {
@@ -10570,8 +10471,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "1692445394927047818"
+                              "version": "0.20.4.51522",
+                              "templateHash": "14572902388080328941"
                             }
                           },
                           "parameters": {
@@ -10813,8 +10714,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "698709463730837083"
+                              "version": "0.20.4.51522",
+                              "templateHash": "5362294501967708784"
                             }
                           },
                           "parameters": {
@@ -10942,15 +10843,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.17.1.54307",
-                              "templateHash": "14445154365330656192"
+                              "version": "0.20.4.51522",
+                              "templateHash": "16757856721763746334"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 64,
                               "minLength": 2,
+                              "maxLength": 64,
                               "metadata": {
                                 "description": "Required. Name of your pruvate endpoint. Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens."
                               }
@@ -11100,8 +11001,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.17.1.54307",
-              "templateHash": "9746862502566108013"
+              "version": "0.20.4.51522",
+              "templateHash": "4741460206960601395"
             }
           },
           "parameters": {
@@ -11159,8 +11060,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "13181302078385014318"
+                      "version": "0.20.4.51522",
+                      "templateHash": "9683203958437324298"
                     }
                   },
                   "parameters": {
@@ -11239,8 +11140,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.17.1.54307",
-                      "templateHash": "13181302078385014318"
+                      "version": "0.20.4.51522",
+                      "templateHash": "9683203958437324298"
                     }
                   },
                   "parameters": {

--- a/scenarios/secure-baseline-multitenant/azure-resource-manager/main.parameters.jsonc
+++ b/scenarios/secure-baseline-multitenant/azure-resource-manager/main.parameters.jsonc
@@ -24,27 +24,27 @@
         // Feature Flags
         // set to true if you want to intercept all outbound traffic with azure firewall
         "enableEgressLockdown" : {
-            "value": "true"
+            "value": true
         },
         // set to true if you want to a redis cache
         "deployRedis": {
-            "value": "false"
+            "value": true
         },
         // set to true if you want to deploy a azure SQL server and default database
         "deployAzureSql": {
-            "value": "true"
+            "value": true
         },
         // set to true if you want to deploy application configuration
         "deployAppConfig": {
-            "value": "true"
+            "value": true
         },
         // set to true if you want to deploy a jumpbox/devops VM
         "deployJumpHost": {
-            "value": "true"
+            "value": true
         },
         // set to true if you want to auto approve the Private Endpoint of the AFD Premium
         "autoApproveAfdPrivateEndpoint": {
-            "value": "true"
+            "value": true
         },
         // CIDR of the subnet that will host the azure Firewall
         "subnetHubFirewallAddressSpace": {

--- a/scenarios/secure-baseline-multitenant/bicep/main.parameters.json
+++ b/scenarios/secure-baseline-multitenant/bicep/main.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "workloadName" : {
-           "value": "appsvclza2"         
+           "value": "appsvclza1"         
         },
         "environmentName": {
             "value": "${AZURE_ENV_NAME}"
@@ -24,13 +24,13 @@
             "value": false
         },
         "deployAzureSql": {
-            "value": true
+            "value": false
         },
         "deployAppConfig": {
             "value": false
         },
         "deployJumpHost": {
-            "value": true
+            "value": false
         },
         "autoApproveAfdPrivateEndpoint": {
             "value": true

--- a/scenarios/secure-baseline-multitenant/bicep/main.parameters.jsonc
+++ b/scenarios/secure-baseline-multitenant/bicep/main.parameters.jsonc
@@ -32,7 +32,7 @@
         },
         // set to true if you want to deploy a azure SQL server and default database
         "deployAzureSql": {
-            "value": "true"
+            "value": true
         },
         // set to true if you want to deploy application configuration
         "deployAppConfig": {

--- a/scenarios/shared/bicep/app-services/app-service-plan.bicep
+++ b/scenarios/shared/bicep/app-services/app-service-plan.bicep
@@ -49,11 +49,6 @@ param targetWorkerSize int = 0
 @description('Optional. The name of the diagnostic setting, if deployed.')
 param diagnosticSettingsName string = '${name}-diagnosticSettings'
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.')
 param diagnosticWorkspaceId string = ''
 
@@ -80,10 +75,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 // https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/patterns-configuration-set#example

--- a/scenarios/shared/bicep/app-services/web-app.bicep
+++ b/scenarios/shared/bicep/app-services/web-app.bicep
@@ -74,10 +74,6 @@ param slots array = []
 param tags object = {}
 
 // Diagnostic Settings
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
 
 @description('Optional. Resource ID of log analytics workspace.')
 param diagnosticWorkspaceId string = ''
@@ -151,20 +147,12 @@ param redundancyMode string = 'None'
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : diagnosticsLogsSpecified
 
@@ -172,10 +160,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')
@@ -315,7 +299,6 @@ module app_slots 'web-app.slots.bicep' = [for (slot, index) in slots: {
     storageAccountId: contains(slot, 'storageAccountId') ? slot.storageAccountId : storageAccountId
     appInsightId: contains(slot, 'appInsightId') ? slot.appInsightId : appInsightId
     setAzureWebJobsDashboard: contains(slot, 'setAzureWebJobsDashboard') ? slot.setAzureWebJobsDashboard : setAzureWebJobsDashboard
-    diagnosticLogsRetentionInDays: contains(slot, 'diagnosticLogsRetentionInDays') ? slot.diagnosticLogsRetentionInDays : diagnosticLogsRetentionInDays
     diagnosticWorkspaceId: diagnosticWorkspaceId
     diagnosticLogCategoriesToEnable: contains(slot, 'diagnosticLogCategoriesToEnable') ? slot.diagnosticLogCategoriesToEnable : diagnosticLogCategoriesToEnable
     diagnosticMetricsToEnable: contains(slot, 'diagnosticMetricsToEnable') ? slot.diagnosticMetricsToEnable : diagnosticMetricsToEnable

--- a/scenarios/shared/bicep/app-services/web-app.slots.bicep
+++ b/scenarios/shared/bicep/app-services/web-app.slots.bicep
@@ -71,11 +71,6 @@ param appSettingsKeyValuePairs object = {}
 param tags object = {}
 
 // Diagnostic Settings
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of log analytics workspace.')
 param diagnosticWorkspaceId string = ''
 
@@ -160,20 +155,12 @@ param vnetRouteAllEnabled bool = false
 var diagnosticsLogs = [for category in diagnosticLogCategoriesToEnable: {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')

--- a/scenarios/shared/bicep/databases/redis.bicep
+++ b/scenarios/shared/bicep/databases/redis.bicep
@@ -62,11 +62,6 @@ param subnetId string = ''
 @description('Optional. The name of the diagnostic setting, if deployed.')
 param diagnosticSettingsName string = '${name}-diagnosticSettings'
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub.')
 param diagnosticWorkspaceId string = ''
 
@@ -93,20 +88,12 @@ param hasPrivateLink bool = false
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : diagnosticsLogsSpecified
 
@@ -114,10 +101,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 // var identityType = systemAssignedIdentity ? 'SystemAssigned' : !empty(userAssignedIdentities) ? 'UserAssigned' : 'None'

--- a/scenarios/shared/bicep/network/firewall.bicep
+++ b/scenarios/shared/bicep/network/firewall.bicep
@@ -52,10 +52,10 @@ param diagnosticStorageAccountId string = ''
 @description('Optional. Log Analytics workspace resource identifier.')
 param diagnosticWorkspaceId string = ''
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
+// @description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
+// @minValue(0)
+// @maxValue(365)
+// param diagnosticLogsRetentionInDays int = 365
 
 @description('Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to.')
 param diagnosticEventHubAuthorizationRuleId string = ''
@@ -96,20 +96,20 @@ var azureSkuName = 'AZFW_VNet'
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
+  // retentionPolicy: {
+  //   enabled: true
+  //   days: diagnosticLogsRetentionInDays
+  // }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
+    // retentionPolicy: {
+    //   enabled: true
+    //   days: diagnosticLogsRetentionInDays
+    // }
   }
 ] : diagnosticsLogsSpecified
 
@@ -117,10 +117,10 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
+  // retentionPolicy: {
+  //   enabled: true
+  //   days: diagnosticLogsRetentionInDays
+  // }
 }]
 
 var ipConfigurations = [{

--- a/scenarios/shared/bicep/network/firewall.bicep
+++ b/scenarios/shared/bicep/network/firewall.bicep
@@ -52,11 +52,6 @@ param diagnosticStorageAccountId string = ''
 @description('Optional. Log Analytics workspace resource identifier.')
 param diagnosticWorkspaceId string = ''
 
-// @description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-// @minValue(0)
-// @maxValue(365)
-// param diagnosticLogsRetentionInDays int = 365
-
 @description('Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to.')
 param diagnosticEventHubAuthorizationRuleId string = ''
 
@@ -96,20 +91,12 @@ var azureSkuName = 'AZFW_VNet'
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  // retentionPolicy: {
-  //   enabled: true
-  //   days: diagnosticLogsRetentionInDays
-  // }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    // retentionPolicy: {
-    //   enabled: true
-    //   days: diagnosticLogsRetentionInDays
-    // }
   }
 ] : diagnosticsLogsSpecified
 
@@ -117,10 +104,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  // retentionPolicy: {
-  //   enabled: true
-  //   days: diagnosticLogsRetentionInDays
-  // }
 }]
 
 var ipConfigurations = [{

--- a/scenarios/shared/bicep/network/front-door.bicep
+++ b/scenarios/shared/bicep/network/front-door.bicep
@@ -61,11 +61,6 @@ param wafPolicyMode string = 'Prevention'
 @description('if no diagnostic serttings are required, provide an empty string. Resource ID of log analytics workspace.')
 param diagnosticWorkspaceId string
 
-@description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-@minValue(0)
-@maxValue(365)
-param diagnosticLogsRetentionInDays int = 365
-
 // Create an Array of all Endpoint which includes customDomain Id and afdEndpoint Id
 // This array is needed to be attached to Microsoft.Cdn/profiles/securitypolicies
 // var customDomainIds = [for (domain, index) in customDomains: {id: custom_domains[index].id}]
@@ -140,20 +135,12 @@ param diagnosticMetricsToEnable array = [
 var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
   category: category
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
   {
     categoryGroup: 'allLogs'
     enabled: true
-    retentionPolicy: {
-      enabled: true
-      days: diagnosticLogsRetentionInDays
-    }
   }
 ] : diagnosticsLogsSpecified
 
@@ -161,10 +148,6 @@ var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric
   timeGrain: null
   enabled: true
-  retentionPolicy: {
-    enabled: true
-    days: diagnosticLogsRetentionInDays
-  }
 }]
 
 @description('Optional. The name of the diagnostic setting, if deployed.')

--- a/scenarios/shared/bicep/storage/storage.queuesvc.bicep
+++ b/scenarios/shared/bicep/storage/storage.queuesvc.bicep
@@ -8,79 +8,6 @@ param name string = 'default'
 @description('Optional. Queues to create.')
 param queues array = []
 
-// @description('Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely.')
-// @minValue(0)
-// @maxValue(365)
-// param diagnosticLogsRetentionInDays int = 365
-
-// @description('Optional. Resource ID of the diagnostic storage account.')
-// param diagnosticStorageAccountId string = ''
-
-// @description('Optional. Resource ID of a log analytics workspace.')
-// param diagnosticWorkspaceId string = ''
-
-// @description('Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to.')
-// param diagnosticEventHubAuthorizationRuleId string = ''
-
-// @description('Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category.')
-// param diagnosticEventHubName string = ''
-
-// @description('Optional. Enable telemetry via the Customer Usage Attribution ID (GUID).')
-// param enableDefaultTelemetry bool = true
-
-// @description('Optional. The name of logs that will be streamed.')
-// @allowed([
-//   'StorageRead'
-//   'StorageWrite'
-//   'StorageDelete'
-// ])
-// param diagnosticLogCategoriesToEnable array = [
-//   'StorageRead'
-//   'StorageWrite'
-//   'StorageDelete'
-// ]
-
-// @description('Optional. The name of metrics that will be streamed.')
-// @allowed([
-//   'Transaction'
-// ])
-// param diagnosticMetricsToEnable array = [
-//   'Transaction'
-// ]
-
-// @description('Optional. The name of the diagnostic setting, if deployed.')
-// param diagnosticSettingsName string = '${name}-diagnosticSettings'
-
-// var diagnosticsLogs = [for category in diagnosticLogCategoriesToEnable: {
-//   category: category
-//   enabled: true
-//   retentionPolicy: {
-//     enabled: true
-//     days: diagnosticLogsRetentionInDays
-//   }
-// }]
-
-// var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
-//   category: metric
-//   timeGrain: null
-//   enabled: true
-//   retentionPolicy: {
-//     enabled: true
-//     days: diagnosticLogsRetentionInDays
-//   }
-// }]
-
-// resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (enableDefaultTelemetry) {
-//   name: 'pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-${uniqueString(deployment().name)}'
-//   properties: {
-//     mode: 'Incremental'
-//     template: {
-//       '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
-//       contentVersion: '1.0.0.0'
-//       resources: []
-//     }
-//   }
-// }
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' existing = {
   name: storageAccountName
@@ -92,18 +19,6 @@ resource queueServices 'Microsoft.Storage/storageAccounts/queueServices@2021-04-
   properties: {}
 }
 
-// resource queueServices_diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if ((!empty(diagnosticStorageAccountId)) || (!empty(diagnosticWorkspaceId)) || (!empty(diagnosticEventHubAuthorizationRuleId)) || (!empty(diagnosticEventHubName))) {
-//   name: diagnosticSettingsName
-//   properties: {
-//     storageAccountId: !empty(diagnosticStorageAccountId) ? diagnosticStorageAccountId : null
-//     workspaceId: !empty(diagnosticWorkspaceId) ? diagnosticWorkspaceId : null
-//     eventHubAuthorizationRuleId: !empty(diagnosticEventHubAuthorizationRuleId) ? diagnosticEventHubAuthorizationRuleId : null
-//     eventHubName: !empty(diagnosticEventHubName) ? diagnosticEventHubName : null
-//     metrics: diagnosticsMetrics
-//     logs: diagnosticsLogs
-//   }
-//   scope: queueServices
-// }
 
 module queueServices_queues 'storage.queuesvc.queues.bicep' = [for (queue, index) in queues: {
   name: '${deployment().name}-Queue-${index}'
@@ -112,8 +27,6 @@ module queueServices_queues 'storage.queuesvc.queues.bicep' = [for (queue, index
     queueServicesName: queueServices.name
     name: queue.name
     metadata: contains(queue, 'metadata') ? queue.metadata : {}
-    // roleAssignments: contains(queue, 'roleAssignments') ? queue.roleAssignments : []
-    // enableDefaultTelemetry: enableDefaultTelemetry
   }
 }]
 


### PR DESCRIPTION
# Description
 A recent change (deprecation) in how you configure azure diagnostics settings retention policy for storage account sink, resulted in deployments failing. 

In our implementation we use Log Analytics Workspace, not storage account, as sink of the diagnostics settings. However, the implementation of the affected modules is based on the CARML repo (which needs to change as well), was not differentiating based on the sink, and it used a "retention"  Policy, which is not valid any more. 

more details of the change you can find here: 
- https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy
- https://github.com/hashicorp/terraform-provider-azurerm/issues/23051

# Type of Change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code